### PR TITLE
forcefield with improper dihedrals,

### DIFF
--- a/atomtypes.atp
+++ b/atomtypes.atp
@@ -1,0 +1,5 @@
+CA    12.01115   ;Aromatic-Hydrogen
+CAL    12.01115   ; Aromatic-Linker
+CL     12.01115   ;Linker
+HT      1.00797    ;Hydrogen
+HA      1.00797    ;Hydrogen

--- a/forcefield.itp
+++ b/forcefield.itp
@@ -1,0 +1,55 @@
+[ defaults ]
+; nbfunc        comb-rule       gen-pairs       fudgeLJ fudgeQQ
+  1             3               yes             0.5     0.5
+
+[atomtypes]
+;name     mass      charge   ptype    sigma        epsilon
+CA   12.01115       -0.115      A   0.355          0.293
+CL   12.01115       0.000       A   0.33           0.419
+CAL  12.01115       0.000       A   0.355          0.293
+HA   1.00797        0.115       A   0.25           0.1257
+
+;[moleculetype]
+; name nrexcl
+;PPE      2
+
+[ bondtypes ]
+; i    j func        b0          kb
+   CL 	  CL    1       0.121      481800.0
+   CL  	  CAL   1       0.1451     167600.0
+   CA     CA    1       0.14       196500.0
+   CA     HA    1       0.108      153800.0
+   CAL    CA    1       0.14       196500.0 
+
+[ angletypes ]
+; i     j       k       funct   angle   force.c.
+  CAL  CL  CL     1    180.0   670.4
+  CAL  CA  CA     1    120.0   263.97
+  CAL  CA  HA     1    120.0   146.65
+  CA   CA  CA     1    120.0   263.97
+  CA   CA  HA     1    120.0   146.65  
+  CA   CAL CA     1    120.0   263.97
+  CA   CAL CL     1    120.0   293.3
+
+[ dihedraltypes ]
+;atom1 atom2 atom3 atom4      funct            C0            C1        C2            C3      C4      C5
+CA       CAL       CL       CL       3         0.0000        0        -0.0000        0       0       0  ;9
+CA       CA        CAL      CL       3        30.3775        0       -30.3775        0       0       0  ;11
+CL       CAL       CA       HA       3        30.3775        0       -30.3775        0       0       0  ;7
+CA       CA        CA       CAL      3        30.3775        0       -30.3775        0       0       0  ;2
+CA       CA        CA       CA       3        30.3775        0       -30.3775        0       0       0  ;5
+CAL      CA        CA       HA       3        30.3775        0       -30.3775        0       0       0  ;4
+CA       CA        CAL      CA       3        30.3775        0       -30.3775        0       0       0  ;6,8
+CAL      CL        CL       CAL      3         0.0000        0        -0.0000        0       0       0  ;10
+CA       CA        CAL      CL       3        30.3775        0       -30.3775        0       0       0  ;11
+HA       CA        CA       HA       3        30.3775        0       -30.3775        0       0       0  ;3
+HA       CA        CA       CA       3        30.3775        0       -30.3775        0       0       0  ;1 care for this
+CA       CAL       CA       HA       3        30.3775        0       -30.3775        0       0       0  ;12 is like 1
+
+; improper dihedrals to keep things flat
+;CA CAL CA HA      2   0.00000     167.400000
+;CA CA  CA  HA      2   0.00000     167.400000
+;CAL CA CLT CA      2   0.00000     167.400000
+;CA  CA HA CA      2   0.00000     167.400000
+;adding improper dihedral for keeping the interaction from CAL to liker flat
+CA   CL   CA   CAL   2   0.00000   96.9578

--- a/residues.rtp
+++ b/residues.rtp
@@ -1,0 +1,101 @@
+[ bondedtypes ]
+;bonds  angles  dihedrals  impropers all_dihedrals nrexcl HH14 RemoveDih
+ 1       1          3          2        0         3      0     1
+
+;Aromatic rings
+[ RNG ]
+ [ atoms ]
+; name | type | charge | charge group
+CA1     CA     -0.115000    1
+CA2     CA     -0.115000    2
+CA3     CA     -0.115000    3
+CA4     CA     -0.115000    4
+CA5     CA     -0.115000    5
+HA1     HA      0.115000    1
+HA2     HA      0.115000    2
+HA3     HA      0.115000    3
+HA4     HA      0.115000    4
+HA5     HA      0.115000    5
+CAL     CAL     0.000000    6
+ [ bonds ]
+CA5    CA1
+CA1    CA2
+CA2    CAL
+CAL    CA3
+CA3    CA4
+CA4    CA5
+CA1    HA1
+CA2    HA2
+CA3    HA3 
+CA4    HA4
+CA5    HA5
+
+ [ dihedrals ]
+;9
+CA2       CAL       +CL1       +CL2 
+CA3       CAL       +CL1       +CL2 
+CA2       CAL       -CL2       -CL1 
+CA3       CAL       -CL2       +CL1
+;11
+CA1       CA2        CAL      +CL1
+CA4       CA3        CAL      +CL1
+CA1       CA2        CAL      -CL2
+CA4       CA3        CAL      -CL2
+;7
++CL1       CAL       CA2       HA2
++CL1       CAL       CA3       HA3
+-CL2       CAL       CA3       HA3
+-CL2       CAL       CA2       HA2
+;2
+CA5       CA1        CA2       CAL
+CA5       CA4        CA3       CAL
+;5
+CA2       CA1        CA5       CA4 
+CA1       CA5        CA4       CA3
+CA3       CA4        CA5       CA1
+;4
+CAL      CA2        CA1       HA1
+CAL      CA3        CA4       HA4
+;6
+CA1       CA2        CAL       CA3
+CA4       CA3        CAL       CA2
+;10
+CAL      +CL1        +CL2      +CAL
+;3
+HA1       CA1        CA2       HA2 
+HA3       CA3        CA4       HA4
+;1
+HA2       CA2        CA1       CA5  
+HA4       CA4        CA5       CA1  
+HA5       CA5        CA1       CA2  
+HA3       CA3        CA4       CA5  
+HA1       CA1        CA5       CA4  
+HA5       CA5        CA4       CA3  
+;12
+HA3       CA3        CAL       CA2
+HA2       CA2        CAL       CA3
+
+; [impropers]
+;CA1 CA5 CA2 HA1
+;CA2 CAL CA1 HA2
+;CA3 CAL CA4 HA3
+;CA4 CA5 CA3 HA4
+;CA5 CA4 CA1 HA5
+
+;Linker chain
+[ ETH ]
+ [ atoms ]
+; name | type | charge | charge group
+CL1     CL    0.000000    7 
+CL2     CL    0.000000    7
+ [ bonds ]
+CL1   CL2
+;bond to the aromatic CAL2  from left
+CL1  -CAL
+;bond to the aromatic CAL1 from right
+CL2  +CAL
+
+ [impropers]
+;adding impropers with fit
+-CA2   CL1   -CA3   -CAL
++CA2   CL2   +CA3   +CAL


### PR DESCRIPTION
This contains a file for parametrization of improper dihedral in FF. this improper is for CAL to linker atoms. In my opinion there is no need to put this improper anymore cause by putting it and checking angle 25 we see by putting the two ring deviate from being flat!
